### PR TITLE
feat: getClosest

### DIFF
--- a/auto-complete.js
+++ b/auto-complete.js
@@ -148,7 +148,7 @@
             }, that.sc);
 
             live('autocomplete-suggestion', 'mousedown', function (e) {
-                if (getClosest(e.target, '.autocomplete-suggestion')) { // else outside click
+                if (getClosest(e.target, '.autocomplete-suggestion') && !getClosest(e.target,'.autocomplete-suggestion--local-remove-button')) { // else outside click
                     var v = this.getAttribute('data-val');
                     var index = this.getAttribute('data-index');
                     if (o.queryHistoryStorageName) {

--- a/auto-complete.js
+++ b/auto-complete.js
@@ -7,14 +7,15 @@
 
 (function (root, factory) {
     if (typeof module === 'object' && module.exports) {
-        module.exports = factory(require('./utils/localStorage'), require('./utils/cache'));
+        module.exports = factory(require('./utils/localStorage'), require('./utils/cache'), require('./utils/dom'));
     } else {
         root.autoComplete = factory(
             root['autoComplete/utils/localStorage'],
-            root['autoComplete/utils/cache']
+            root['autoComplete/utils/cache'],
+            root['autoComplete/utils/dom']
         );
     }
-}(typeof self !== 'undefined' ? self : this, function (_localStorage, _cache) {
+}(typeof self !== 'undefined' ? self : this, function (_localStorage, _cache, _dom) {
     // "use strict";
 
     var removeQueryFromLocalStorage = _localStorage.removeQueryFromLocalStorage,
@@ -23,6 +24,7 @@
         removeDuplicatedQueries = _localStorage.removeDuplicatedQueries;
 
     var removeSuggestionFromCache = _cache.removeSuggestionFromCache;
+    var getClosest = _dom.getClosest;
 
     var requestId = 0;
 
@@ -146,7 +148,7 @@
             }, that.sc);
 
             live('autocomplete-suggestion', 'mousedown', function (e) {
-                if (hasClass(e.target, 'autocomplete-suggestion')) { // else outside click
+                if (getClosest(e.target, '.autocomplete-suggestion')) { // else outside click
                     var v = this.getAttribute('data-val');
                     var index = this.getAttribute('data-index');
                     if (o.queryHistoryStorageName) {

--- a/tests/utils/dom.js
+++ b/tests/utils/dom.js
@@ -1,0 +1,52 @@
+var _dom = require('../../utils/dom'),
+
+getClosest = _dom.getClosest;
+
+describe('DOM related functions', function() {
+  describe('getClosest', function() {
+    beforeEach(function() {
+      document.body.innerHTML =
+        '<div class="autocomplete-suggestions ">' +
+        '  <div class="autocomplete-suggestion  selected"' +
+        '    data-url="https://escritorioonline.jusbrasil.com.br/contatos/jbprofile:13174584:AUTOMATIC:9753809"' +
+        '    data-val="Leonice Alves">' +
+        '    <div class="autocomplete-thumb">' +
+        '      <div class="avatar avatar--circle avatar--sm avatar--bluegray">L</div>' +
+        '    </div>' +
+        '    <div class="autocomplete-suggestion-text">' +
+        '      <span class="autocomplete-suggestion-text-title">Leonice Alves</span>' +
+        '      <span class="autocomplete-suggestion-text-description">Cliente em potencial</span>' +
+        '    </div>' +
+        '  </div>' +
+        '</div>';
+    });
+
+    it('should return null properly if no matching parent was found', function() {
+      var targetEl = document.querySelector('.autocomplete-suggestion-text-title');
+      var expectedClosest = null;
+      expect(getClosest(targetEl, '.unknown')).toEqual(expectedClosest);
+    });
+
+    it('should return the closest properly if parent was found', function() {
+      var targetEl = document.querySelector('.autocomplete-suggestion-text-title');
+      var expectedClosest = document.querySelector('.autocomplete-suggestion');
+      expect(getClosest(targetEl, '.autocomplete-suggestion')).toEqual(expectedClosest);
+    });
+
+    it('should polyfill Element.matches properly', function() {
+      var originalElementPrototype = Element.prototype;
+      delete Element.prototype.matches;
+      delete Element.prototype.matchesSelector;
+      delete Element.prototype.mozMatchesSelector;
+      delete Element.prototype.msMatchesSelector;
+      delete Element.prototype.oMatchesSelector;
+      delete Element.prototype.webkitMatchesSelector;
+
+      var targetEl = document.querySelector('.autocomplete-suggestion-text-title');
+      var expectedClosest = document.querySelector('.autocomplete-suggestion');
+      expect(getClosest(targetEl, '.autocomplete-suggestion')).toEqual(expectedClosest);
+
+      Element.prototype = originalElementPrototype;
+    });
+  });
+})

--- a/utils/dom.js
+++ b/utils/dom.js
@@ -1,0 +1,36 @@
+function getClosest (elem, selector) {
+  // Element.matches() polyfill
+  if (!Element.prototype.matches) {
+    Element.prototype.matches =
+    Element.prototype.matchesSelector ||
+    Element.prototype.mozMatchesSelector ||
+    Element.prototype.msMatchesSelector ||
+    Element.prototype.oMatchesSelector ||
+    Element.prototype.webkitMatchesSelector ||
+    function(s) {
+      var matches = (this.document || this.ownerDocument).querySelectorAll(s),
+      i = matches.length;
+      while (--i >= 0 && matches.item(i) !== this) {}
+      return i > -1;
+    };
+  }
+
+  // Get the closest matching element
+  for ( ; elem && elem !== document; elem = elem.parentNode ) {
+    if ( elem.matches( selector ) ) return elem;
+  }
+  return null;
+};
+
+(function (root, factory) {
+  if (typeof module === 'object' && module.exports) {
+    module.exports = factory();
+  } else {
+    root['autoComplete/utils/dom'] = factory();
+  }
+}(typeof self !== 'undefined' ? self : this, function () {
+
+  return {
+    getClosest: getClosest,
+  };
+}));


### PR DESCRIPTION
**Why is this PR necessary, what does it do?**

This PR introduces the `getClosest` function also with support for IE to fix the autocomplete suggestion element click.

###### demo

| before | after |
|---|---|
| ![autocomplete-suggestion-target--before](https://user-images.githubusercontent.com/5435389/87470593-5d399100-c5f3-11ea-974c-10fca3ed92e1.gif) | ![autocomplete-suggestion-target--after](https://user-images.githubusercontent.com/5435389/87470595-5e6abe00-c5f3-11ea-8101-dfc53a0be945.gif) |

**References:**

- https://jusbrasil.slack.com/archives/CJZQ74R32/p1594743252015400

**Technical Notes:**

n/a