### PR TITLE
Fix exact match in local storage

### DIFF
--- a/auto-complete.js
+++ b/auto-complete.js
@@ -80,7 +80,8 @@
             onSelect: function (e, term, item) { },
             queryHistoryStorageName: null,
             formSelector: null,
-            buildTerm: function (term) { return term }
+            buildTerm: function (term) { return term },
+            target: null
         };
         for (var k in options) { if (options.hasOwnProperty(k)) o[k] = options[k]; }
 
@@ -182,7 +183,7 @@
             var suggest = function (data) {
                 var val = that.value;
                 if (o.queryHistoryStorageName) {
-                    var localQueries = getQueriesFromLocalStorage(o.queryHistoryStorageName, val);
+                    var localQueries = getQueriesFromLocalStorage(o.queryHistoryStorageName, o.buildTerm(val), o.target);
                     if (val.length >= o.minChars) {
                         data = localQueries.concat(data);
                         data = removeDuplicatedQueries(data);

--- a/auto-complete.js
+++ b/auto-complete.js
@@ -183,7 +183,7 @@
             var suggest = function (data) {
                 var val = that.value;
                 if (o.queryHistoryStorageName) {
-                    var localQueries = getQueriesFromLocalStorage(o.queryHistoryStorageName, o.buildTerm(val), o.target);
+                    var localQueries = getQueriesFromLocalStorage(o.queryHistoryStorageName, o.buildTerm(val.toLowerCase()), o.target);
                     if (val.length >= o.minChars) {
                         data = localQueries.concat(data);
                         data = removeDuplicatedQueries(data);

--- a/tests/auto-complete.js
+++ b/tests/auto-complete.js
@@ -53,7 +53,7 @@ describe('Autocomplete Instance', function () {
 
     });
 
-    it('should show all local storage queries when queryHistoryStorageName is not null input is empty', function () {
+    it('should show all local storage queries when queryHistoryStorageName is not null and input is empty', function () {
         // GIVEN
         autoComplete({
             selector: '.Test',

--- a/tests/auto-complete.js
+++ b/tests/auto-complete.js
@@ -5,6 +5,19 @@ function removeSpaces(text) {
     return text.trim().replace(/\s/g, '');
 }
 
+function buildTerm(term) {
+    return {
+        target: term
+    }
+}
+
+function renderItem(item, prefix, index) {
+
+    return '<div class="autocomplete-suggestion" data-val="' + item.target + '" data-index="' + index + '">' + item.target + '</div>';
+
+
+}
+
 
 describe('Autocomplete Instance', function () {
     jest.useFakeTimers();
@@ -58,9 +71,12 @@ describe('Autocomplete Instance', function () {
         autoComplete({
             selector: '.Test',
             source: function (a, callback) { callback([]) },
-            queryHistoryStorageName: 'localTest'
+            queryHistoryStorageName: 'localTest',
+            buildTerm: buildTerm,
+            renderItem: renderItem,
+            target: 'target'
         });
-        window.localStorage.setItem('localTest', JSON.stringify(['1', '2']))
+        window.localStorage.setItem('localTest', JSON.stringify([{ target: '1' }, { target: '2' }]))
         var clickEvent = new Event('click');
         var inputBox = document.querySelector('.Test');
         var suggestions = document.querySelector('.autocomplete-suggestions');
@@ -70,8 +86,8 @@ describe('Autocomplete Instance', function () {
 
         // THEN
         expect(removeSpaces(suggestions.innerHTML)).toBe(removeSpaces(`
-        <div class="autocomplete-suggestion" data-val="2" data-index="0"><b></b>2<b></b></div>
-        <div class="autocomplete-suggestion" data-val="1" data-index="1"><b></b>1<b></b></div>
+        <div class="autocomplete-suggestion" data-val="<b></b>2" data-index="0"><b></b>2</div>
+        <div class="autocomplete-suggestion" data-val="<b></b>1" data-index="1"><b></b>1</div>
         `));
     });
 
@@ -103,9 +119,12 @@ describe('Autocomplete Instance', function () {
                 callback(['suggestion 1', 'suggestion 2']);
             },
             queryHistoryStorageName: 'localTest',
+            renderItem: renderItem,
+            buildTerm: buildTerm,
+            target: 'target',
             minChars: 3
         });
-        window.localStorage.setItem('localTest', JSON.stringify(['suggestion local 1', 'suggestion local 2']))
+        window.localStorage.setItem('localTest', JSON.stringify([{ target: 'suggestion local 1' }, { target: 'suggestion local 2' }]))
         var keyPressEvent = new KeyboardEvent('keyup');
         var inputBox = document.querySelector('.Test');
         inputBox.value = 'su';
@@ -118,10 +137,10 @@ describe('Autocomplete Instance', function () {
         // THEN
         expect(removeSpaces(suggestions.innerHTML)).toBe(removeSpaces(`
         <div class="autocomplete-suggestion" data-val="<b>su</b>ggestion local 2" data-index="0">
-            <b><b>su</b></b>ggestion local 2
+            <b>su</b>ggestion local 2
         </div>
         <div class="autocomplete-suggestion" data-val="<b>su</b>ggestion local 1" data-index="1">
-            <b><b>su</b></b>ggestion local 1
+            <b>su</b>ggestion local 1
         </div>
         `));
     });
@@ -183,12 +202,15 @@ describe('Autocomplete Instance', function () {
             delay: 0,
             selector: '.Test',
             source: function (a, callback) {
-                callback(['suggestion 1', 'suggestion 2']);
+                callback([{ target: '<b>sugg</b>estion 1' }, { target: '<b>sugg</b>estion 2' }]);
             },
             queryHistoryStorageName: 'localTest',
+            renderItem: renderItem,
+            buildTerm: buildTerm,
+            target: 'target',
             minChars: 3
         });
-        window.localStorage.setItem('localTest', JSON.stringify(['suggestion local 1', 'suggestion local 2']))
+        window.localStorage.setItem('localTest', JSON.stringify([{ target: 'suggestion local 1' }, { target: 'suggestion local 2' }]))
         var keyPressEvent = new KeyboardEvent('keyup');
         var inputBox = document.querySelector('.Test');
         inputBox.value = 'sugg';
@@ -201,15 +223,15 @@ describe('Autocomplete Instance', function () {
         // THEN
         expect(removeSpaces(suggestions.innerHTML)).toBe(removeSpaces(`
         <div class="autocomplete-suggestion" data-val="<b>sugg</b>estion local 2" data-index="0">
-            <b><b>sugg</b></b>estion local 2
+            <b>sugg</b>estion local 2
         </div>
         <div class="autocomplete-suggestion" data-val="<b>sugg</b>estion local 1" data-index="1">
-            <b><b>sugg</b></b>estion local 1
+            <b>sugg</b>estion local 1
         </div>
-        <div class="autocomplete-suggestion" data-val="suggestion 1" data-index="2">
+        <div class="autocomplete-suggestion" data-val="<b>sugg</b>estion 1" data-index="2">
             <b>sugg</b>estion 1
         </div>
-        <div class="autocomplete-suggestion" data-val="suggestion 2" data-index="3">
+        <div class="autocomplete-suggestion" data-val="<b>sugg</b>estion 2" data-index="3">
             <b>sugg</b>estion 2
         </div>
         `));
@@ -220,10 +242,13 @@ describe('Autocomplete Instance', function () {
         autoComplete({
             selector: '.Test',
             source: function (a, callback) { callback([]) },
-            queryHistoryStorageName: 'localTest'
+            queryHistoryStorageName: 'localTest',
+            buildTerm: buildTerm,
+            renderItem: renderItem,
+            target: 'target'
         });
         window.event = 'true';
-        window.localStorage.setItem('localTest', JSON.stringify(['1', '2']))
+        window.localStorage.setItem('localTest', JSON.stringify([{ target: '1' }, { target: '2' }]))
         var clickEvent = new Event('click');
         var arrowEvent = new KeyboardEvent('keydown', { keyCode: 40 });
         var inputBox = document.querySelector('.Test');

--- a/tests/utils/localStorage.js
+++ b/tests/utils/localStorage.js
@@ -118,13 +118,13 @@ describe('Local storage functions', function () {
 
     it('should return matched queries with bold propety in matched characters', function () {
         // GIVEN 
-        addQueryToLocalStorage(testStorageName, 'testing');
+        addQueryToLocalStorage(testStorageName, {target: "testing"});
 
         // WHEN 
-        var queries = getQueriesFromLocalStorage(testStorageName, 'test');
+        var queries = getQueriesFromLocalStorage(testStorageName, { target: "test" }, 'target');
 
         // THEN
-        expect(queries).toMatchObject(['<b>test</b>ing']);
+        expect(queries).toMatchObject([{target:'<b>test</b>ing',isQueryHistory:true}]);
     });
 
     it('should remove queries with same title', function () {

--- a/tests/utils/localStorage.js
+++ b/tests/utils/localStorage.js
@@ -104,13 +104,13 @@ describe('Local storage functions', function () {
         expect(queries).toEqual([]);
     })
 
-    it('should returned formated queries', function () {
+    it('should returne formated queries', function () {
         // GIVEN
         addQueryToLocalStorage(testStorageName, { target: 'first' });
         addQueryToLocalStorage(testStorageName, { target: '[a]bo{b}ora' }); //special characters test
 
         // WHEN
-        var queries = getQueriesFromLocalStorage(testStorageName, '[a]bo{b}o');
+        var queries = getQueriesFromLocalStorage(testStorageName, { target: '[a]bo{b}o' }, 'target');
 
         // THEN
         expect(queries).toMatchObject([{ target: '<b>[a]bo{b}o</b>ra', isQueryHistory: true }])

--- a/utils/localStorage.js
+++ b/utils/localStorage.js
@@ -48,21 +48,33 @@
         }
     }
 
-    function getQueriesFromLocalStorage(storageName, term) {
+    function getQueriesFromLocalStorage(storageName, term, target) {
         var queries = getSuggestionQueries(storageName);
         if (queries !== null) {
-            term = escapeSpecialChars(term);
             var matchedQueries = queries.map(function (query) {
-                query = JSON.stringify(query);
-                var regex = new RegExp(term);
-                var match = regex.exec(query);
-                if (match !== null) {
-                    if (term.length) {
-                        query = query.replace(match[0], '<b>'.concat(match[0], '</b>'));
+                var match
+                var regex
+                if (target !== null && query[target]) {
+                    regex = new RegExp('^'+escapeSpecialChars(term[target]));
+                    match = regex.exec(query[target]);
+                    if (match !== null) {
+                        query[target] = query[target].replace(match[0], '<b>'.concat(match[0], '</b>'))
+                        query.isQueryHistory = true;
+                        return query
                     }
-                    query = JSON.parse(query);
-                    query.isQueryHistory = true;
-                    return query;
+                } else {
+                    term = escapeSpecialChars(term);
+                    query = JSON.stringify(query);
+                    regex = new RegExp(term)
+                    match = regex.exec(query)
+                    if (match !== null) {
+                        if (term.length) {
+                            query = query.replace(match[0], '<b>'.concat(match[0], '</b>'));
+                        }
+                        query = JSON.parse(query);
+                        query.isQueryHistory = true;
+                        return query;
+                    }
                 }
                 return null;
             });

--- a/utils/localStorage.js
+++ b/utils/localStorage.js
@@ -62,19 +62,6 @@
                         query.isQueryHistory = true;
                         return query
                     }
-                } else {
-                    term = escapeSpecialChars(term);
-                    query = JSON.stringify(query);
-                    regex = new RegExp(term)
-                    match = regex.exec(query)
-                    if (match !== null) {
-                        if (term.length) {
-                            query = query.replace(match[0], '<b>'.concat(match[0], '</b>'));
-                        }
-                        query = JSON.parse(query);
-                        query.isQueryHistory = true;
-                        return query;
-                    }
                 }
                 return null;
             });


### PR DESCRIPTION
In this PR we add one more parameter to the autocomplete.

This will help to fix the bug to the exact match in local storage queries. 
We need because of the way we store the queries in the local storage is generic so the application using this pass as a parameter how we should format the queries.